### PR TITLE
Update flit requirements to move psycopg2 

### DIFF
--- a/flit.ini
+++ b/flit.ini
@@ -15,9 +15,9 @@ classifiers = License :: OSI Approved :: MIT License
 description-file=README-pypi.rst
 requires=docker
     typing; python_version < '3.5'
+    psycopg2
 dev-requires=sqlalchemy
-             sqlalchemy_utils
-             sqllogformatter
-             psycopg2
-             pytest
-             redis
+    sqlalchemy_utils
+    sqllogformatter
+    pytest
+    redis


### PR DESCRIPTION
from dev-requires to requires (to support pg_ready)

Fixes #3 